### PR TITLE
fix InvalidCastException

### DIFF
--- a/src/AgentSmith/Comments/IdentifierResolver.cs
+++ b/src/AgentSmith/Comments/IdentifierResolver.cs
@@ -28,7 +28,7 @@ namespace AgentSmith.Comments
 
             if (methodDecl != null)
             {
-                foreach (ILocalRegularParameterDeclaration parm in methodDecl.ParameterDeclarations)
+                foreach (IParameterDeclaration parm in methodDecl.ParameterDeclarations)
                 {
                     if (parm.DeclaredName == word)
                     {


### PR DESCRIPTION
ILocalRegularParameterDeclaration  is used for local and anonymous functions and lambdas. MethodDeclarations have parameter declarations of type ICSharpRegularParameterDeclaration